### PR TITLE
Move player controls to `Control` class and move physic control to `PhysicOController` class  && some typecheck fix

### DIFF
--- a/src/Control.luau
+++ b/src/Control.luau
@@ -1,3 +1,5 @@
+--!strict
+
 local Players = game:GetService("Players")
 
 local PlayerModule =

--- a/src/Control.luau
+++ b/src/Control.luau
@@ -1,0 +1,365 @@
+local Players = game:GetService("Players")
+
+local PlayerModule =
+	require(Players.LocalPlayer.PlayerScripts:WaitForChild("PlayerModule"))
+
+local player = require(script.Parent.player)
+local InputLib = require(script.Parent.Parent.InputLib)
+local ControlType = require(script.Parent.ControlType)
+local stdlib = require(script.Parent.Parent.stdlib)
+local map = require(script.Parent.map)
+
+local Control = {}
+
+export type ControlStruct = {
+	ControlThread: thread?,
+	Player: player.Player2d,
+
+	--[[
+		List of objects that will be destroyed on Destroy call
+	]]
+	DestroyableObjects: {
+		Up: InputLib.WhileKeyPressedController?,
+		Down: InputLib.WhileKeyPressedController?,
+		Right: InputLib.WhileKeyPressedController?,
+		Left: InputLib.WhileKeyPressedController?,
+		Gamepad: InputLib.WhileKeyPressedController?,
+
+		[any]: any,
+	},
+
+	ControllerSettings: ControlType.Control,
+
+	--[[
+	
+	]]
+	CooldownTime: number,
+
+	--[[
+		Map
+	]]
+	Map: map.Map,
+
+	Moving: boolean,
+
+	MoveTween: Tween?,
+
+	CollideMutex: stdlib.Mutex,
+
+	--[[
+		Sent on physic step end
+	]]
+	CollideStepped: RBXScriptSignal<>,
+
+	--[[
+	
+	]]
+	Destroying: RBXScriptSignal<>,
+
+	--[[
+	
+	]]
+	CollideSteppedEvent: BindableEvent<>,
+}
+
+export type Control = typeof(setmetatable(
+	{} :: ControlStruct,
+	{ __index = Control }
+))
+
+local function showAnimation(self: Control, animationName: string)
+	if self.MoveTween then
+		self.MoveTween:Destroy()
+		self.MoveTween = nil -- set to nil for this IF can working
+	else
+		print("bbb")
+	end
+
+	self.Player:SetAnimation(animationName)
+end
+
+function Control.IDLE(self: Control)
+	showAnimation(
+		self,
+		"IDLE"
+			.. stdlib.algorithm.GetIndexs(self.Player.Animations.IDLE)[math.random(
+				#self.Player.Animations.IDLE
+			)]
+	)
+end
+
+function Control.Up(self: Control)
+	Control.Move(self, 0, 1)
+end
+
+function Control.Down(self: Control)
+	Control.Move(self, 0, -1)
+end
+
+function Control.Left(self: Control)
+	Control.Move(self, -1, 0)
+end
+
+function Control.Right(self: Control)
+	Control.Move(self, 1, 0)
+end
+
+function Control.LeftUp(self: Control)
+	Control.Move(self, -1, 1)
+end
+
+function Control.LeftDown(self: Control)
+	Control.Move(self, -1, -1)
+end
+
+function Control.RightUp(self: Control)
+	Control.Move(self, 1, 1)
+end
+
+function Control.RightDown(self: Control)
+	Control.Move(self, 1, -1)
+end
+
+--[[
+	Move player
+]]
+function Control.Move(self: Control, X: number, Y: number)
+	if not self.Moving then
+		self.Moving = true
+
+		if self.MoveTween then
+			self.MoveTween:Destroy()
+			self.MoveTween = nil -- set to nil for this IF can working
+		end
+
+		self.CollideMutex:wait()
+
+		self.MoveTween =
+			self.Player:WalkMove(X, Y, self.Map.Image, self.CooldownTime)
+
+		if self.MoveTween then
+			self.MoveTween:Play()
+		end
+
+		self.Moving = false
+	end
+end
+
+--[[
+	Start game
+]]
+function Control.Start(self: Control)
+	self.ControlThread = task.spawn(function()
+		self.Player:SetAnimation("IDLE")
+
+		-- Keyboard controls
+
+		local function w(_: InputObject, _: boolean): boolean
+			task.wait()
+			return true
+		end
+
+		self.DestroyableObjects.Up = InputLib.WhileKeyPressed(w, {
+			self.ControllerSettings.Keyboard.Up,
+			self.ControllerSettings.Gamepad.Up,
+			Enum.KeyCode.Up,
+		})
+
+		self.DestroyableObjects.Down = InputLib.WhileKeyPressed(w, {
+			self.ControllerSettings.Keyboard.Down,
+			self.ControllerSettings.Gamepad.Down,
+			Enum.KeyCode.Down,
+		})
+
+		self.DestroyableObjects.Right = InputLib.WhileKeyPressed(w, {
+			self.ControllerSettings.Keyboard.Right,
+			self.ControllerSettings.Gamepad.Right,
+			Enum.KeyCode.Right,
+		})
+
+		self.DestroyableObjects.Left = InputLib.WhileKeyPressed(w, {
+			self.ControllerSettings.Keyboard.Left,
+			self.ControllerSettings.Gamepad.Left,
+			Enum.KeyCode.Left,
+		})
+
+		-- gamepad input
+
+		local GamepadThumbStick1 = Instance.new("Vector3Value")
+
+		self.DestroyableObjects.Gamepad = InputLib.WhileKeyPressed(
+			function(InputObject: InputObject, a1: boolean)
+				if
+					Players.LocalPlayer.Character.Humanoid.MoveDirection
+					~= Vector3.new()
+				then
+					GamepadThumbStick1.Value = PlayerModule:GetControls()
+						:GetMoveVector()
+					return true
+				end
+
+				return false
+			end,
+			{
+				Enum.KeyCode.Thumbstick1,
+				Enum.KeyCode.Unknown,
+			}
+		)
+
+		if
+			self.DestroyableObjects.Up
+			and self.DestroyableObjects.Down
+			and self.DestroyableObjects.Right
+			and self.DestroyableObjects.Left
+			and self.DestroyableObjects.Gamepad
+		then
+			local function Move(_self: Control, XPos: number?, YPos: number?)
+				self.CollideSteppedEvent:Fire()
+				if
+					self.DestroyableObjects.Up.State.Value
+					and self.DestroyableObjects.Right.State.Value
+				then --	Right Up
+					Control.RightUp(_self)
+				elseif
+					self.DestroyableObjects.Down.State.Value
+					and self.DestroyableObjects.Right.State.Value
+				then -- Right Down
+					Control.RightDown(_self)
+				elseif
+					self.DestroyableObjects.Down.State.Value
+					and self.DestroyableObjects.Left.State.Value
+				then --	Left Down
+					Control.LeftDown(_self)
+				elseif
+					self.DestroyableObjects.Up.State.Value
+					and self.DestroyableObjects.Left.State.Value
+				then --	Left Up
+					Control.LeftUp(_self)
+				elseif self.DestroyableObjects.Up.State.Value then --	Up
+					Control.Up(_self)
+				elseif self.DestroyableObjects.Down.State.Value then --	Down
+					Control.Down(_self)
+				elseif self.DestroyableObjects.Left.State.Value then --	Left
+					Control.Left(_self)
+				elseif self.DestroyableObjects.Right.State.Value then --	Right
+					Control.Right(_self)
+				elseif YPos and XPos then
+					Control.Move(_self, XPos, YPos)
+				else
+					warn(
+						"No key pressed and positions of X and Y are not indicated"
+					)
+				end
+			end
+
+			stdlib.events
+				.AnyEvent({
+					self.DestroyableObjects.Up.Called,
+					self.DestroyableObjects.Down.Called,
+					self.DestroyableObjects.Right.Called,
+					self.DestroyableObjects.Left.Called,
+				}).Event
+				:Connect(function(_: any)
+					Move(self)
+				end)
+
+			self.DestroyableObjects.Gamepad.Called:Connect(function(_: any)
+				Move(
+					self,
+					GamepadThumbStick1.Value.X,
+					-GamepadThumbStick1.Value.Z
+				)
+			end)
+
+			-- other
+
+			stdlib.events.AnyEvent({
+				self.Map.ObjectMovement,
+				self.Player.Move,
+			}, self.CollideSteppedEvent)
+
+			--[[
+
+			]]
+			local IDLE_show_thread = task.spawn(function()
+				--[[
+					Короче как оно работает:
+
+					Когда игрок нажимает клавишу начинаем отсчет времени.
+
+					Если во время ожидания была нажата ещё клавиша, то сбрасываем ожидание и ждем следующего.
+
+					> При длительном зажатии получается что что цикл повторяется, что может создать проблемы с производительностью
+				]]
+				local t
+
+				self.Player.Move:Connect(function()
+					if t then
+						task.cancel(t)
+					end
+				end)
+
+				self.Player.Move:Connect(function()
+					t = task.spawn(function()
+						wait(4)
+
+						self:IDLE()
+					end)
+				end)
+			end)
+
+			self.CollideStepped:Connect(function()
+				self.CollideMutex:lock()
+				self.Map:CalcCollide()
+				self.CollideMutex:unlock()
+			end)
+
+			self.CollideStepped:Connect(function()
+				self.Map:CalcZIndexs()
+			end)
+
+			self.Destroying:Connect(function()
+				task.cancel(IDLE_show_thread)
+				GamepadThumbStick1:Destroy()
+			end)
+		end
+	end)
+end
+
+function Control.Pause(self: Control)
+	if self.DestroyableObjects.Up then
+		self.DestroyableObjects.Up.Pause()
+	end
+	if self.DestroyableObjects.Down then
+		self.DestroyableObjects.Down.Pause()
+	end
+	if self.DestroyableObjects.Left then
+		self.DestroyableObjects.Left.Pause()
+	end
+	if self.DestroyableObjects.Right then
+		self.DestroyableObjects.Right.Pause()
+	end
+	if self.DestroyableObjects.Gamepad then
+		self.DestroyableObjects.Gamepad.Pause()
+	end
+end
+
+function Control.Resume(self: Control)
+	if self.DestroyableObjects.Up then
+		self.DestroyableObjects.Up.Resume()
+	end
+	if self.DestroyableObjects.Down then
+		self.DestroyableObjects.Down.Resume()
+	end
+	if self.DestroyableObjects.Left then
+		self.DestroyableObjects.Left.Resume()
+	end
+	if self.DestroyableObjects.Right then
+		self.DestroyableObjects.Right.Resume()
+	end
+	if self.DestroyableObjects.Gamepad then
+		self.DestroyableObjects.Gamepad.Resume()
+	end
+end
+
+return Control

--- a/src/PhysicController.luau
+++ b/src/PhysicController.luau
@@ -1,0 +1,58 @@
+local stdlib = require(script.Parent.Parent.stdlib)
+local algorithm = stdlib.algorithm
+
+local physicObject = require(script.Parent.physicObject)
+
+local PhysicController = {}
+
+export type PhysicControllerStruct = {
+
+	Objects: { [number]: physicObject.PhysicObject },
+}
+
+export type PhysicController = typeof(setmetatable(
+	{} :: PhysicControllerStruct,
+	{ __index = PhysicController }
+))
+
+function PhysicController.CalcPositions(self: PhysicController)
+	for _, v in pairs(self.Objects) do
+		v:CalcSizeAndPos()
+	end
+end
+
+function PhysicController.CalcCollide(self: PhysicController)
+	--[[
+		Список объектов которые имеют коллизию
+	]]
+	local Objects: { physicObject.PhysicObject } = algorithm.copy_if(
+		self.Objects,
+		function(value): boolean
+			return value.CanCollide
+				and (value.PhysicMode > physicObject.PhysicMode.NoPhysic)
+		end
+	)
+
+	for _, v: physicObject.PhysicObject in pairs(Objects) do
+		v:StartPhysicCalc()
+	end
+
+	for _, v: physicObject.PhysicObject in pairs(Objects) do
+		local i = algorithm.copy_if(
+			Objects,
+			function(value: physicObject.PhysicObject): boolean
+				return value ~= v and physicObject.CheckCollision(v, value)
+			end
+		)
+
+		for _, obj in pairs(i) do
+			v.TouchedEvent:Fire(obj)
+			v:CalcTouchedSide(obj)
+		end
+	end
+
+	for _, v: physicObject.PhysicObject in pairs(Objects) do
+		v:DonePhysicCalc()
+	end
+end
+return PhysicController

--- a/src/game.lua
+++ b/src/game.lua
@@ -1,6 +1,3 @@
---!strict
-
-local cooldown = require(script.Parent.Parent.cooldown)
 local stdlib = require(script.Parent.Parent.stdlib)
 local mutex = stdlib.mutex
 

--- a/src/game.lua
+++ b/src/game.lua
@@ -1,11 +1,5 @@
 --!strict
 
-local Players = game:GetService("Players")
-
-local PlayerModule =
-	require(Players.LocalPlayer.PlayerScripts:WaitForChild("PlayerModule"))
-
-local InputLib = require(script.Parent.Parent.InputLib)
 local cooldown = require(script.Parent.Parent.cooldown)
 local stdlib = require(script.Parent.Parent.stdlib)
 local mutex = stdlib.mutex
@@ -14,11 +8,12 @@ local ControlType = require(script.Parent.ControlType)
 local defaultControls = require(script.Parent.defaultControls)
 local map = require(script.Parent.map)
 local player = require(script.Parent.player)
+local Control = require(script.Parent.Control)
 
 --[[
 	Класс игры
 ]]
-local Game = {}
+local Game = setmetatable({}, { __index = Control })
 
 export type GameStruct = {
 	--[[
@@ -30,39 +25,6 @@ export type GameStruct = {
 		Player
 	]]
 	Player: player.Player2d,
-
-	--[[
-		Map
-	]]
-	Map: map.Map,
-
-	--[[
-		Sent on physic step end
-	]]
-	CollideStepped: RBXScriptSignal<>,
-
-	--[[
-	
-	]]
-	Destroying: RBXScriptSignal<>,
-
-	--[[
-	
-	]]
-	CooldownTime: number,
-
-	--[[
-		List of objects that will be destroyed on Destroy call
-	]]
-	DestroyableObjects: {
-		Up: InputLib.WhileKeyPressedController?,
-		Down: InputLib.WhileKeyPressedController?,
-		Right: InputLib.WhileKeyPressedController?,
-		Left: InputLib.WhileKeyPressedController?,
-		Gamepad: InputLib.WhileKeyPressedController?,
-
-		[any]: any,
-	},
 
 	--[[
 	
@@ -79,18 +41,10 @@ export type GameStruct = {
 	]]
 	CollideSteppedEvent: BindableEvent<>,
 
-	MoveTween: Tween?,
-
-	CollideMutex: stdlib.Mutex,
-
-	Moving: boolean,
-
 	ControlThread: thread?,
+} & Control.ControlStruct
 
-	ControllerSettings: ControlType.Control,
-}
-
-export type Game = typeof(setmetatable({} :: GameStruct, { __index = Game }))
+export type Game = GameStruct & typeof(Game) & Control.Control
 
 --[[
 
@@ -114,84 +68,6 @@ function Game.Destroy(self: GameStruct)
 	self.CollideSteppedEvent:Destroy()
 	self.Player:Destroy()
 	self.DestroyingEvent:Destroy()
-end
-
-local function showAnimation(self: Game, animationName: string)
-	if self.MoveTween then
-		self.MoveTween:Destroy()
-		self.MoveTween = nil -- set to nil for this IF can working
-	else
-		print("bbb")
-	end
-
-	self.Player:SetAnimation(animationName)
-end
-
-function Game.IDLE(self: Game)
-	showAnimation(
-		self,
-		"IDLE"
-			.. stdlib.algorithm.GetIndexs(self.Player.Animations.IDLE)[math.random(
-				#self.Player.Animations.IDLE
-			)]
-	)
-end
-
-function Game.Up(self: Game)
-	Game.Move(self, 0, 1)
-end
-
-function Game.Down(self: Game)
-	Game.Move(self, 0, -1)
-end
-
-function Game.Left(self: Game)
-	Game.Move(self, -1, 0)
-end
-
-function Game.Right(self: Game)
-	Game.Move(self, 1, 0)
-end
-
-function Game.LeftUp(self: Game)
-	Game.Move(self, -1, 1)
-end
-
-function Game.LeftDown(self: Game)
-	Game.Move(self, -1, -1)
-end
-
-function Game.RightUp(self: Game)
-	Game.Move(self, 1, 1)
-end
-
-function Game.RightDown(self: Game)
-	Game.Move(self, 1, -1)
-end
-
---[[
-	Move player
-]]
-function Game.Move(self: Game, X: number, Y: number)
-	if not self.Moving then
-		self.Moving = true
-
-		if self.MoveTween then
-			self.MoveTween:Destroy()
-			self.MoveTween = nil -- set to nil for this IF can working
-		end
-
-		self.CollideMutex:wait()
-
-		self.MoveTween =
-			self.Player:WalkMove(X, Y, self.Map.Image, self.CooldownTime)
-
-		if self.MoveTween then
-			self.MoveTween:Play()
-		end
-
-		self.Moving = false
-	end
 end
 
 --[[
@@ -240,221 +116,6 @@ function Game.Loading(self: Game)
 end
 
 --[[
-	Start game
-]]
-function Game.Start(self: Game)
-	self.ControlThread = task.spawn(function()
-		self.Player:SetAnimation("IDLE")
-
-		-- Keyboard controls
-
-		local function w(_: InputObject, _: boolean): boolean
-			task.wait()
-			return true
-		end
-
-		self.DestroyableObjects.Up = InputLib.WhileKeyPressed(w, {
-			self.ControllerSettings.Keyboard.Up,
-			self.ControllerSettings.Gamepad.Up,
-			Enum.KeyCode.Up,
-		})
-
-		self.DestroyableObjects.Down = InputLib.WhileKeyPressed(w, {
-			self.ControllerSettings.Keyboard.Down,
-			self.ControllerSettings.Gamepad.Down,
-			Enum.KeyCode.Down,
-		})
-
-		self.DestroyableObjects.Right = InputLib.WhileKeyPressed(w, {
-			self.ControllerSettings.Keyboard.Right,
-			self.ControllerSettings.Gamepad.Right,
-			Enum.KeyCode.Right,
-		})
-
-		self.DestroyableObjects.Left = InputLib.WhileKeyPressed(w, {
-			self.ControllerSettings.Keyboard.Left,
-			self.ControllerSettings.Gamepad.Left,
-			Enum.KeyCode.Left,
-		})
-
-		-- gamepad input
-
-		local GamepadThumbStick1 = Instance.new("Vector3Value")
-
-		self.DestroyableObjects.Gamepad = InputLib.WhileKeyPressed(
-			function(InputObject: InputObject, a1: boolean)
-				if
-					Players.LocalPlayer.Character.Humanoid.MoveDirection
-					~= Vector3.new()
-				then
-					GamepadThumbStick1.Value = PlayerModule:GetControls()
-						:GetMoveVector()
-					return true
-				end
-
-				return false
-			end,
-			{
-				Enum.KeyCode.Thumbstick1,
-				Enum.KeyCode.Unknown,
-			}
-		)
-
-		if
-			self.DestroyableObjects.Up
-			and self.DestroyableObjects.Down
-			and self.DestroyableObjects.Right
-			and self.DestroyableObjects.Left
-			and self.DestroyableObjects.Gamepad
-		then
-			local function Move(_self: Game, XPos: number?, YPos: number?)
-				self.CollideSteppedEvent:Fire()
-				if
-					self.DestroyableObjects.Up.State.Value
-					and self.DestroyableObjects.Right.State.Value
-				then --	Right Up
-					Game.RightUp(_self)
-				elseif
-					self.DestroyableObjects.Down.State.Value
-					and self.DestroyableObjects.Right.State.Value
-				then -- Right Down
-					Game.RightDown(_self)
-				elseif
-					self.DestroyableObjects.Down.State.Value
-					and self.DestroyableObjects.Left.State.Value
-				then --	Left Down
-					Game.LeftDown(_self)
-				elseif
-					self.DestroyableObjects.Up.State.Value
-					and self.DestroyableObjects.Left.State.Value
-				then --	Left Up
-					Game.LeftUp(_self)
-				elseif self.DestroyableObjects.Up.State.Value then --	Up
-					Game.Up(_self)
-				elseif self.DestroyableObjects.Down.State.Value then --	Down
-					Game.Down(_self)
-				elseif self.DestroyableObjects.Left.State.Value then --	Left
-					Game.Left(_self)
-				elseif self.DestroyableObjects.Right.State.Value then --	Right
-					Game.Right(_self)
-				elseif YPos and XPos then
-					Game.Move(_self, XPos, YPos)
-				else
-					warn(
-						"No key pressed and positions of X and Y are not indicated"
-					)
-				end
-			end
-
-			stdlib.events.AnyEvent({
-				self.DestroyableObjects.Up.Called,
-				self.DestroyableObjects.Down.Called,
-				self.DestroyableObjects.Right.Called,
-				self.DestroyableObjects.Left.Called,
-			}).Event:Connect(function(_: any)
-				Move(self)
-			end)
-
-			self.DestroyableObjects.Gamepad.Called:Connect(function(_: any)
-				Move(
-					self,
-					GamepadThumbStick1.Value.X,
-					-GamepadThumbStick1.Value.Z
-				)
-			end)
-
-			-- other
-
-			stdlib.events.AnyEvent({
-				self.Map.ObjectMovement,
-				self.Player.Move,
-			}, self.CollideSteppedEvent)
-
-			--[[
-
-			]]
-			local IDLE_show_thread = task.spawn(function()
-				--[[
-					Короче как оно работает:
-
-					Когда игрок нажимает клавишу начинаем отсчет времени.
-
-					Если во время ожидания была нажата ещё клавиша, то сбрасываем ожидание и ждем следующего.
-
-					> При длительном зажатии получается что что цикл повторяется, что может создать проблемы с производительностью
-				]]
-				local t
-
-				self.Player.Move:Connect(function()
-					if t then
-						task.cancel(t)
-					end
-				end)
-
-				self.Player.Move:Connect(function()
-					t = task.spawn(function()
-						wait(4)
-
-						self:IDLE()
-					end)
-				end)
-			end)
-
-			self.CollideStepped:Connect(function()
-				self.CollideMutex:lock()
-				self.Map:CalcCollide()
-				self.CollideMutex:unlock()
-			end)
-
-			self.CollideStepped:Connect(function()
-				self.Map:CalcZIndexs()
-			end)
-
-			self.Destroying:Connect(function()
-				task.cancel(IDLE_show_thread)
-				GamepadThumbStick1:Destroy()
-			end)
-		end
-	end)
-end
-
-function Game.Pause(self: Game)
-	if self.DestroyableObjects.Up then
-		self.DestroyableObjects.Up.Pause()
-	end
-	if self.DestroyableObjects.Down then
-		self.DestroyableObjects.Down.Pause()
-	end
-	if self.DestroyableObjects.Left then
-		self.DestroyableObjects.Left.Pause()
-	end
-	if self.DestroyableObjects.Right then
-		self.DestroyableObjects.Right.Pause()
-	end
-	if self.DestroyableObjects.Gamepad then
-		self.DestroyableObjects.Gamepad.Pause()
-	end
-end
-
-function Game.Resume(self: Game)
-	if self.DestroyableObjects.Up then
-		self.DestroyableObjects.Up.Resume()
-	end
-	if self.DestroyableObjects.Down then
-		self.DestroyableObjects.Down.Resume()
-	end
-	if self.DestroyableObjects.Left then
-		self.DestroyableObjects.Left.Resume()
-	end
-	if self.DestroyableObjects.Right then
-		self.DestroyableObjects.Right.Resume()
-	end
-	if self.DestroyableObjects.Gamepad then
-		self.DestroyableObjects.Gamepad.Resume()
-	end
-end
-
---[[
 	Game constructor
 ]]
 function Game.new(
@@ -491,9 +152,7 @@ function Game.new(
 
 	setmetatable(self, { __index = Game })
 
-	showAnimation(self, "IDLE")
-
-	return self
+	return self :: Game
 end
 
 return Game

--- a/src/physicObject.lua
+++ b/src/physicObject.lua
@@ -332,7 +332,8 @@ function physicObject.GetTouchMsg(
 	obj: PhysicObject
 ): boolean?
 	mutex.wait(obj.TouchMsgMutex)
-	return self.TouchMsg[obj.ID]
+	local a = self.TouchMsg
+	return a[obj.ID]
 end
 
 --[[
@@ -345,7 +346,8 @@ function physicObject.SetTouchMsg(
 )
 	self.TouchMsgMutex:wait()
 	self.TouchMsgMutex:lock()
-	self.TouchMsg[obj.ID] = val or true
+	local t = self.TouchMsg
+	t[obj.ID] = val or true
 	self.TouchMsgMutex:unlock()
 end
 
@@ -559,15 +561,16 @@ function physicObject.new(
 			end
 
 			if not obj.Anchored and physicObject.GetTouchMsg(obj, this) then
-				calc(this, obj, 2)
-				this:SetTouchMsg(obj)
+				local a = this :: PhysicObject
+				calc(a, obj, 2)
+				a:SetTouchMsg(obj)
 			else
-				calc(this, obj, 1)
+				calc(this :: PhysicObject, obj, 1)
 			end
 		end
 	end)
 
-	return this
+	return this :: PhysicObject
 end
 
 return physicObject

--- a/src/physicObject.lua
+++ b/src/physicObject.lua
@@ -96,7 +96,7 @@ export type PhysicObjectStruct = {
 	TransparencyOnFocusedBack: number,
 
 	InFocus: boolean,
-  
+
 	PhysicMode: number,
 
 	checkingTouchedSize: boolean,
@@ -528,7 +528,8 @@ function physicObject.new(
 		if
 			not this.Anchored
 			and this.PhysicMode >= physicObject.PhysicMode.CanCollide
-			and obj.PhysicMode >= physicObject.PhysicMode.CanCollide
+			and obj.PhysicMode :: number
+				>= physicObject.PhysicMode.CanCollide
 		then
 			this.TouchedSideMutex:wait()
 


### PR DESCRIPTION
idk why, but Roblox studio say(lint error):
```
Type Error: (131,2) Type
	'{| CollideMutex: Mutex, CollideStepped: RBXScriptSignal, ... 13 more ... |} where t1 = { Anchored: boolean, CanCollide: boolean, ID: number, ... 15 more ... } & { Image: { ImageInstance: ImageLabel, RealSize: Vector2 } } & { Move: RBXScriptSignal, MoveEvent: BindableEvent, ... 1 more ... } & { @metatable { __index: any }, { Destroy: (t1) -> (...any), GetMoveTween: (t1, number, number, { ImageInstance: ImageLabel, RealSize: Vector2 }, number?) -> Tween?, ... 4 more ... } } & any & { @metatable { __index: { Preload: ({ @metatable *CYCLE*, { Image: { ImageInstance: ImageLabel, RealSize: Vector2 } } }) -> {string}, ... 1 more ... } }, { Image: { ImageInstance: ImageLabel, RealSize: Vector2 } } } & { Anchored: boolean, CanCollide: boolean, ID: number, ... 15 more ... } & { Image: { ImageInstance: ImageLabel, RealSize: Vector2 } }... *TRUNCATED*'
could not be converted into
	'ControlStruct & { CollideSteppedEvent: BindableEvent, Connections: {RBXScriptConnection}, ... 4 more ... } where t1 = { Anchored: boolean, CanCollide: boolean, ID: number, ... 15 more ... } & { Image: { ImageInstance: ImageLabel, RealSize: Vector2 } } & { Move: RBXScriptSignal, MoveEvent: BindableEvent, ... 1 more ... } & { @metatable { __index: any }, { Destroy: (t1) -> (...any), GetMoveTween: (t1, number, number, { ImageInstance: ImageLabel, RealSize: Vector2 }, number?) -> Tween?, ... 4 more ... } }... *TRUNCATED*'
caused by:
  Not all intersection parts are compatible.
Type
	'{| CollideMutex: Mutex, CollideStepped: RBXScriptSignal, ... 13 more ... |} where t1 = { Anchored: boolean, CanCollide: boolean, ID: number, ... 15 more ... } & { Image: { ImageInstance: ImageLabel, RealSize: Vector2 } } & { Move: RBXScriptSignal, MoveEvent: BindableEvent, ... 1 more ... } & { @metatable { __index: any }, { Destroy: (t1) -> (...any), GetMoveTween: (t1, number, number, { ImageInstance: ImageLabel, RealSize: Vector2 }, number?) -> Tween?, ... 4 more ... } } & any & { @metatable { __index: { Preload: ({ @metatable *CYCLE*, { Image: { ImageInstance: ImageLabel, RealSize: Vector2 } } }) -> {string}, ... 1 more ... } }, { Image: { ImageInstance: ImageLabel, RealSize: Vector2 } } } & { Anchored: boolean, CanCollide: boolean, ID: number, ... 15 more ... } & { Image: { ImageInstance: ImageLabel, RealSize: Vector2 } }... *TRUNCATED*'
could not be converted into
	'ControlStruct'
caused by:
  Property 'CollideStepped' is not compatible.
Type
	'RBXScriptSignal' from 'Roblox'
could not be converted into
	'RBXScriptSignal' from 'Roblox' in an invariant context
```