### PR TITLE
Fix `Map:DeletePlayer` function

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,6 +14,7 @@
 		"dialoglib",
 		"getmetatable",
 		"giflib",
+		"maxn",
 		"nonstrict",
 		"pcall",
 		"rbxassetid",

--- a/src/map.lua
+++ b/src/map.lua
@@ -225,7 +225,7 @@ function map.DeletePlayer(self: Map, Player: player2d.Player2d)
 	local p = table.find(Objects, Player)
 
 	if p then
-		Objects[p] = nil
+		table.remove(Objects, p)
 	end
 end
 

--- a/tests/TestMovableObjects/test.client.luau
+++ b/tests/TestMovableObjects/test.client.luau
@@ -11,7 +11,9 @@ adventure2d.config.ShowHitboxes = true
 
 Players.LocalPlayer:WaitForChild("PlayerGui"):WaitForChild("ScreenGui")
 
-local GameFrame = Players.LocalPlayer.PlayerGui:WaitForChild("ScreenGui") :WaitForChild("Frame") :: Frame
+local GameFrame = Players.LocalPlayer.PlayerGui
+	:WaitForChild("ScreenGui")
+	:WaitForChild("Frame") :: Frame
 GameFrame.Size = UDim2.fromScale(1, 1)
 
 local _game = adventure2d.Game.new(

--- a/tests/demo/test.client.luau
+++ b/tests/demo/test.client.luau
@@ -73,7 +73,12 @@ local map1 = map.new(Vector2.new(1, 1), cam, "114575775575709", {
 	shee,
 }, Vector2.new(80, 300), Vector3.new(22, 48, 8))
 
-local map2 = map.new(Vector2.new(1, 1), cam, "113837532573611")
+local ChangeBack2 = adventure2d.Object2d.new(Vector2.new(15, 414), Vector3.new(65, 50, 50), adventure2d.ExImage.new(""))
+
+local map2 = map.new(Vector2.new(1, 1), cam, "113837532573611",
+{
+	ChangeBack2
+})
 
 local _game = Game.new(GameFrame, player, map1)
 
@@ -83,6 +88,10 @@ _game:Start()
 
 changeMap.Touched:Connect(function(_)
 	_game:SetMap(map2)
+end)
+
+ChangeBack2.Touched:Connect(function()
+	_game:SetMap(map1)
 end)
 
 local faceId: string ="rbxassetid://117978347308606"

--- a/tests/demo/test.client.luau
+++ b/tests/demo/test.client.luau
@@ -73,11 +73,14 @@ local map1 = map.new(Vector2.new(1, 1), cam, "114575775575709", {
 	shee,
 }, Vector2.new(80, 300), Vector3.new(22, 48, 8))
 
-local ChangeBack2 = adventure2d.Object2d.new(Vector2.new(15, 414), Vector3.new(65, 50, 50), adventure2d.ExImage.new(""))
+local ChangeBack2 = adventure2d.Object2d.new(
+	Vector2.new(15, 414),
+	Vector3.new(65, 50, 50),
+	adventure2d.ExImage.new("")
+)
 
-local map2 = map.new(Vector2.new(1, 1), cam, "113837532573611",
-{
-	ChangeBack2
+local map2 = map.new(Vector2.new(1, 1), cam, "113837532573611", {
+	ChangeBack2,
 })
 
 local _game = Game.new(GameFrame, player, map1)
@@ -94,7 +97,7 @@ ChangeBack2.Touched:Connect(function()
 	_game:SetMap(map1)
 end)
 
-local faceId: string ="rbxassetid://117978347308606"
+local faceId: string = "rbxassetid://117978347308606"
 local d = dialoglib.dialog.new(DialogFrame, {
 	dialoglib.phrase.new(
 		"This is a demo. Nothing",

--- a/tests/shared/animations.luau
+++ b/tests/shared/animations.luau
@@ -6,7 +6,6 @@ local giflib = require(ReplicatedStorage.Packages.giflib)
 local audio = require(script.Parent.audio)
 local adventure2d = require(ReplicatedStorage.Packages["2d-adventure"])
 
-
 return {
 	["IDLE"] = {
 		["a"] = adventure2d.Animation.new(

--- a/tests/shared/audio.luau
+++ b/tests/shared/audio.luau
@@ -20,5 +20,4 @@ w2.Parent = workspace
 w2.SourceInstance = audio.Stay
 w2.TargetInstance = out
 
-
 return audio

--- a/tests/shared/player.luau
+++ b/tests/shared/player.luau
@@ -5,4 +5,8 @@ local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local animations = require(script.Parent.animations)
 local adventure2d = require(ReplicatedStorage.Packages["2d-adventure"])
 
-return adventure2d.Player2d.new(animations, { X = 10, Y = 9 }, Vector3.new(25, 50, 4))
+return adventure2d.Player2d.new(
+	animations,
+	{ X = 10, Y = 9 },
+	Vector3.new(25, 50, 4)
+)


### PR DESCRIPTION
```
ReplicatedStorage.Packages.2d-adventure.map:188: attempt to index nil with 'physicImage'  -  Client - map:188
  18:09:53.951  Stack Begin  -  Studio
  18:09:53.951  Script 'ReplicatedStorage.Packages.2d-adventure.map', Line 188  -  Studio - map:188
  18:09:53.951  Script 'ReplicatedStorage.Packages.2d-adventure.map', Line 182 - function CalcZIndexs  -  Studio - map:182
  18:09:53.951  Script 'ReplicatedStorage.Packages.2d-adventure.map', Line 123 - function CalcPositions  -  Studio - map:123
  18:09:53.952  Script 'ReplicatedStorage.Packages.2d-adventure.map', Line 145 - function Init  -  Studio - map:145
  18:09:53.952  Script 'ReplicatedStorage.Packages.2d-adventure.game', Line 89 - function SetMap  -  Studio - game:89
  18:09:53.952  Script 'Players.Egor_00f.PlayerScripts.test', Line 94  -  Studio - test:94
  18:09:53.952  Stack End  -  Studio
```